### PR TITLE
feat: conditional compilation for iOS to remove unnecessary permissions

### DIFF
--- a/ios/Permissions/RNPAudioVideo.h
+++ b/ios/Permissions/RNPAudioVideo.h
@@ -5,6 +5,8 @@
 //  Created by Yonah Forst on 11/07/16.
 //  Copyright © 2016 Yonah Forst. All rights reserved.
 //
+#import "RNPFeature.h"
+#ifdef RNP_USE_AUDIOVIDEO
 
 #import <Foundation/Foundation.h>
 #import "RCTConvert+RNPStatus.h"
@@ -15,3 +17,5 @@
 + (void)request:(NSString *)type completionHandler:(void (^)(NSString *))completionHandler;
 
 @end
+
+#endif

--- a/ios/Permissions/RNPAudioVideo.m
+++ b/ios/Permissions/RNPAudioVideo.m
@@ -5,9 +5,10 @@
 //  Created by Yonah Forst on 11/07/16.
 //  Copyright © 2016 Yonah Forst. All rights reserved.
 //
+#import "RNPFeature.h"
+#ifdef RNP_USE_AUDIOVIDEO
 
 #import "RNPAudioVideo.h"
-
 #import <AVFoundation/AVFoundation.h>
 
 @implementation RNPAudioVideo
@@ -46,3 +47,5 @@
 }
 
 @end
+
+#endif

--- a/ios/Permissions/RNPBluetooth.h
+++ b/ios/Permissions/RNPBluetooth.h
@@ -5,6 +5,8 @@
 //  Created by Yonah Forst on 11/07/16.
 //  Copyright © 2016 Yonah Forst. All rights reserved.
 //
+#import "RNPFeature.h"
+#ifdef RNP_USE_BLUETOOTH
 
 #import <Foundation/Foundation.h>
 #import "RCTConvert+RNPStatus.h"
@@ -15,3 +17,5 @@
 - (void)request:(void (^)(NSString *))completionHandler;
 
 @end
+
+#endif

--- a/ios/Permissions/RNPBluetooth.m
+++ b/ios/Permissions/RNPBluetooth.m
@@ -5,6 +5,8 @@
 //  Created by Yonah Forst on 11/07/16.
 //  Copyright © 2016 Yonah Forst. All rights reserved.
 //
+#import "RNPFeature.h"
+#ifdef RNP_USE_BLUETOOTH
 
 #import "RNPBluetooth.h"
 #import <CoreBluetooth/CoreBluetooth.h>
@@ -64,3 +66,5 @@
 }
 
 @end
+
+#endif

--- a/ios/Permissions/RNPContacts.h
+++ b/ios/Permissions/RNPContacts.h
@@ -5,6 +5,8 @@
 //  Created by Yonah Forst on 11/07/16.
 //  Copyright © 2016 Yonah Forst. All rights reserved.
 //
+#import "RNPFeature.h"
+#ifdef RNP_USE_CONTACT
 
 #import <Foundation/Foundation.h>
 #import "RCTConvert+RNPStatus.h"
@@ -15,3 +17,5 @@
 + (void)request:(void (^)(NSString *))completionHandler;
 
 @end
+
+#endif

--- a/ios/Permissions/RNPContacts.m
+++ b/ios/Permissions/RNPContacts.m
@@ -5,6 +5,8 @@
 //  Created by Yonah Forst on 11/07/16.
 //  Copyright © 2016 Yonah Forst. All rights reserved.
 //
+#import "RNPFeature.h"
+#ifdef RNP_USE_CONTACT
 
 #import "RNPContacts.h"
 #import <AddressBook/AddressBook.h>
@@ -67,3 +69,5 @@
 }
 
 @end
+
+#endif

--- a/ios/Permissions/RNPEvent.h
+++ b/ios/Permissions/RNPEvent.h
@@ -5,6 +5,8 @@
 //  Created by Yonah Forst on 11/07/16.
 //  Copyright © 2016 Yonah Forst. All rights reserved.
 //
+#import "RNPFeature.h"
+#ifdef RNP_USE_CALENDAR
 
 #import <Foundation/Foundation.h>
 #import "RCTConvert+RNPStatus.h"
@@ -15,3 +17,5 @@
 + (void)request:(NSString *)type completionHandler:(void (^)(NSString *))completionHandler;
 
 @end
+
+#endif

--- a/ios/Permissions/RNPEvent.m
+++ b/ios/Permissions/RNPEvent.m
@@ -5,6 +5,8 @@
 //  Created by Yonah Forst on 11/07/16.
 //  Copyright © 2016 Yonah Forst. All rights reserved.
 //
+#import "RNPFeature.h"
+#ifdef RNP_USE_CALENDAR
 
 #import "RNPEvent.h"
 #import <EventKit/EventKit.h>
@@ -46,3 +48,5 @@
 }
 
 @end
+
+#endif

--- a/ios/Permissions/RNPFeature.h
+++ b/ios/Permissions/RNPFeature.h
@@ -1,0 +1,48 @@
+//
+//  RNPFeature.h
+//  ReactNativePermissions
+//
+//  Created by Jian Wei on 2019/3/8.
+//  Copyright © 2019年 Yonah Forst. All rights reserved.
+//
+
+#ifndef RNPFeature_h
+#define RNPFeature_h
+
+#if (defined(RNP_ALL) || defined(RNP_LOCATION)) && !defined(RNP_LOCATION_REMOVE)
+#define RNP_USE_LOCATION
+#endif
+
+#if (defined(RNP_ALL) || defined(RNP_CALENDAR)) && !defined(RNP_CALENDAR_REMOVE)
+#define RNP_USE_CALENDAR
+#endif
+
+#if (defined(RNP_ALL) || defined(RNP_BLUETOOTH)) && !defined(RNP_BLUETOOTH_REMOVE)
+#define RNP_USE_BLUETOOTH
+#endif
+
+#if (defined(RNP_ALL) || defined(RNP_AUDIOVIDEO)) && !defined(RNP_AUDIOVIDEO_REMOVE)
+#define RNP_USE_AUDIOVIDEO
+#endif
+
+#if (defined(RNP_ALL) || defined(RNP_PHOTO)) && !defined(RNP_PHOTO_REMOVE)
+#define RNP_USE_PHOTO
+#endif
+
+#if (defined(RNP_ALL) || defined(RNP_CONTACT)) && !defined(RNP_CONTACT_REMOVE)
+#define RNP_USE_CONTACT
+#endif
+
+#if (defined(RNP_ALL) || defined(RNP_SPEECH)) && !defined(RNP_SPEECH_REMOVE)
+#define RNP_USE_SPEECH
+#endif
+
+#if (defined(RNP_ALL) || defined(RNP_MOTION)) && !defined(RNP_MOTION_REMOVE)
+#define RNP_USE_MOTION
+#endif
+
+#if (defined(RNP_ALL) || defined(RNP_MEDIALIBRARY)) && !defined(RNP_MEDIALIBRARY_REMOVE)
+#define RNP_USE_MEDIALIBRARY
+#endif
+
+#endif /* RNPFeature_h */

--- a/ios/Permissions/RNPLocation.h
+++ b/ios/Permissions/RNPLocation.h
@@ -5,6 +5,8 @@
 //  Created by Yonah Forst on 11/07/16.
 //  Copyright © 2016 Yonah Forst. All rights reserved.
 //
+#import "RNPFeature.h"
+#ifdef RNP_USE_LOCATION
 
 #import <Foundation/Foundation.h>
 #import "RCTConvert+RNPStatus.h"
@@ -15,3 +17,5 @@
 - (void)request:(NSString *)type completionHandler:(void (^)(NSString *))completionHandler;
 
 @end
+
+#endif

--- a/ios/Permissions/RNPLocation.m
+++ b/ios/Permissions/RNPLocation.m
@@ -5,6 +5,8 @@
 //  Created by Yonah Forst on 11/07/16.
 //  Copyright © 2016 Yonah Forst. All rights reserved.
 //
+#import "RNPFeature.h"
+#ifdef RNP_USE_LOCATION
 
 #import "RNPLocation.h"
 #import <CoreLocation/CoreLocation.h>
@@ -76,3 +78,5 @@
     }
 }
 @end
+
+#endif

--- a/ios/Permissions/RNPMediaLibrary.h
+++ b/ios/Permissions/RNPMediaLibrary.h
@@ -5,6 +5,8 @@
 //  Created by Yonah Forst on 11/07/16.
 //  Copyright © 2016 Yonah Forst. All rights reserved.
 //
+#import "RNPFeature.h"
+#ifdef RNP_USE_MEDIALIBRARY
 
 #import <Foundation/Foundation.h>
 #import "RCTConvert+RNPStatus.h"
@@ -15,3 +17,5 @@
 + (void)request:(void (^)(NSString *))completionHandler;
 
 @end
+
+#endif

--- a/ios/Permissions/RNPMediaLibrary.m
+++ b/ios/Permissions/RNPMediaLibrary.m
@@ -5,6 +5,8 @@
 //  Created by Yonah Forst on 11/07/16.
 //  Copyright © 2016 Yonah Forst. All rights reserved.
 //
+#import "RNPFeature.h"
+#ifdef RNP_USE_MEDIALIBRARY
 
 #import "RNPMediaLibrary.h"
 #import <MediaPlayer/MediaPlayer.h>
@@ -39,3 +41,5 @@
     }];
 }
 @end
+
+#endif

--- a/ios/Permissions/RNPMotion.h
+++ b/ios/Permissions/RNPMotion.h
@@ -2,6 +2,8 @@
 //  RNPMotion.h
 //  ReactNativePermissions
 //
+#import "RNPFeature.h"
+#ifdef RNP_USE_MOTION
 
 #import <Foundation/Foundation.h>
 #import "RCTConvert+RNPStatus.h"
@@ -12,3 +14,5 @@
 + (void)request:(void (^)(NSString *))completionHandler;
 
 @end
+
+#endif

--- a/ios/Permissions/RNPMotion.m
+++ b/ios/Permissions/RNPMotion.m
@@ -2,6 +2,8 @@
 //  RNPMotion.m
 //  ReactNativePermissions
 //
+#import "RNPFeature.h"
+#ifdef RNP_USE_MOTION
 
 #import "RNPMotion.h"
 #import <CoreMotion/CoreMotion.h>
@@ -60,3 +62,5 @@
     }
 }
 @end
+
+#endif

--- a/ios/Permissions/RNPPhoto.h
+++ b/ios/Permissions/RNPPhoto.h
@@ -5,6 +5,8 @@
 //  Created by Yonah Forst on 11/07/16.
 //  Copyright © 2016 Yonah Forst. All rights reserved.
 //
+#import "RNPFeature.h"
+#ifdef RNP_USE_PHOTO
 
 #import <Foundation/Foundation.h>
 #import "RCTConvert+RNPStatus.h"
@@ -15,3 +17,5 @@
 + (void)request:(void (^)(NSString *))completionHandler;
 
 @end
+
+#endif

--- a/ios/Permissions/RNPPhoto.m
+++ b/ios/Permissions/RNPPhoto.m
@@ -5,6 +5,8 @@
 //  Created by Yonah Forst on 11/07/16.
 //  Copyright © 2016 Yonah Forst. All rights reserved.
 //
+#import "RNPFeature.h"
+#ifdef RNP_USE_PHOTO
 
 #import "RNPPhoto.h"
 #import <AssetsLibrary/AssetsLibrary.h>
@@ -41,3 +43,5 @@
     }];
 }
 @end
+
+#endif

--- a/ios/Permissions/RNPSpeechRecognition.h
+++ b/ios/Permissions/RNPSpeechRecognition.h
@@ -5,6 +5,8 @@
 //  Created by Tres Trantham on 1/11/17.
 //  Copyright © 2017 Yonah Forst. All rights reserved.
 //
+#import "RNPFeature.h"
+#ifdef RNP_USE_SPEECH
 
 #import <Foundation/Foundation.h>
 #import "RCTConvert+RNPStatus.h"
@@ -15,3 +17,5 @@
 + (void)request:(void (^)(NSString *))completionHandler;
 
 @end
+
+#endif

--- a/ios/Permissions/RNPSpeechRecognition.m
+++ b/ios/Permissions/RNPSpeechRecognition.m
@@ -5,6 +5,8 @@
 //  Created by Tres Trantham on 1/11/17.
 //  Copyright © 2017 Yonah Forst. All rights reserved.
 //
+#import "RNPFeature.h"
+#ifdef RNP_USE_SPEECH
 
 #import "RNPSpeechRecognition.h"
 #import <Speech/Speech.h>
@@ -42,3 +44,5 @@
 }
 
 @end
+
+#endif

--- a/ios/ReactNativePermissions.m
+++ b/ios/ReactNativePermissions.m
@@ -9,6 +9,7 @@
 @import Contacts;
 
 #import "ReactNativePermissions.h"
+#import "RNPFeature.h"
 
 #if __has_include(<React/RCTBridge.h>)
   #import <React/RCTBridge.h>
@@ -34,23 +35,53 @@
   #import "RCTEventDispatcher.h"
 #endif
 
+#ifdef RNP_USE_LOCATION
 #import "RNPLocation.h"
-#import "RNPBluetooth.h"
-#import "RNPNotification.h"
-#import "RNPAudioVideo.h"
-#import "RNPEvent.h"
-#import "RNPPhoto.h"
-#import "RNPContacts.h"
-#import "RNPBackgroundRefresh.h"
-#import "RNPSpeechRecognition.h"
-#import "RNPMediaLibrary.h"
-#import "RNPMotion.h"
+#endif
 
+#ifdef RNP_USE_CALENDAR
+#import "RNPEvent.h"
+#endif
+
+#ifdef RNP_USE_BLUETOOTH
+#import "RNPBluetooth.h"
+#endif
+
+#ifdef RNP_USE_AUDIOVIDEO
+#import "RNPAudioVideo.h"
+#endif
+
+#ifdef RNP_USE_PHOTO
+#import "RNPPhoto.h"
+#endif
+
+#ifdef RNP_USE_CONTACT
+#import "RNPContacts.h"
+#endif
+
+#ifdef RNP_USE_SPEECH
+#import "RNPSpeechRecognition.h"
+#endif
+
+#ifdef RNP_USE_MOTION
+#import "RNPMotion.h"
+#endif
+
+#ifdef RNP_USE_MEDIALIBRARY
+#import "RNPMediaLibrary.h"
+#endif
+
+#import "RNPNotification.h"
+#import "RNPBackgroundRefresh.h"
 
 @interface ReactNativePermissions()
+#ifdef RNP_USE_LOCATION
 @property (strong, nonatomic) RNPLocation *locationMgr;
-@property (strong, nonatomic) RNPNotification *notificationMgr;
+#endif
+#ifdef RNP_USE_BLUETOOTH
 @property (strong, nonatomic) RNPBluetooth *bluetoothMgr;
+#endif
+@property (strong, nonatomic) RNPNotification *notificationMgr;
 @end
 
 @implementation ReactNativePermissions
@@ -113,48 +144,67 @@ RCT_REMAP_METHOD(getPermissionStatus, getPermissionStatus:(RNPType)type json:(id
 
     switch (type) {
 
+#ifdef RNP_USE_LOCATION
         case RNPTypeLocation: {
             NSString *locationPermissionType = [RCTConvert NSString:json];
             status = [RNPLocation getStatusForType:locationPermissionType];
             break;
         }
+#endif
+#ifdef RNP_USE_AUDIOVIDEO
         case RNPTypeCamera:
             status = [RNPAudioVideo getStatus:@"video"];
             break;
         case RNPTypeMicrophone:
             status = [RNPAudioVideo getStatus:@"audio"];
             break;
+#endif
+#ifdef RNP_USE_PHOTO
         case RNPTypePhoto:
             status = [RNPPhoto getStatus];
             break;
+#endif
+#ifdef RNP_USE_CONTACT
         case RNPTypeContacts:
             status = [RNPContacts getStatus];
             break;
+#endif
+#ifdef RNP_USE_CALENDAR
         case RNPTypeEvent:
             status = [RNPEvent getStatus:@"event"];
             break;
         case RNPTypeReminder:
             status = [RNPEvent getStatus:@"reminder"];
             break;
+#endif
+#ifdef RNP_USE_BLUETOOTH
         case RNPTypeBluetooth:
             status = [RNPBluetooth getStatus];
             break;
+#endif
         case RNPTypeNotification:
             status = [RNPNotification getStatus];
             break;
         case RNPTypeBackgroundRefresh:
             status = [RNPBackgroundRefresh getStatus];
             break;
+#ifdef RNP_USE_SPEECH
         case RNPTypeSpeechRecognition:
             status = [RNPSpeechRecognition getStatus];
             break;
+#endif
+#ifdef RNP_USE_MEDIALIBRARY
         case RNPTypeMediaLibrary:
             status = [RNPMediaLibrary getStatus];
             break;
+#endif
+#ifdef RNP_USE_MOTION
         case RNPTypeMotion:
             status = [RNPMotion getStatus];
             break;
+#endif
         default:
+            status = RNPStatusUndetermined;
             break;
     }
 
@@ -166,37 +216,54 @@ RCT_REMAP_METHOD(requestPermission, permissionType:(RNPType)type json:(id)json r
     NSString *status;
 
     switch (type) {
+#ifdef RNP_USE_LOCATION
         case RNPTypeLocation:
             return [self requestLocation:json resolve:resolve];
+#endif
+#ifdef RNP_USE_AUDIOVIDEO
         case RNPTypeCamera:
             return [RNPAudioVideo request:@"video" completionHandler:resolve];
         case RNPTypeMicrophone:
             return [RNPAudioVideo request:@"audio" completionHandler:resolve];
+#endif
+#ifdef RNP_USE_PHOTO
         case RNPTypePhoto:
             return [RNPPhoto request:resolve];
+#endif
+#ifdef RNP_USE_CONTACT
         case RNPTypeContacts:
             return [RNPContacts request:resolve];
+#endif
+#ifdef RNP_USE_CALENDAR
         case RNPTypeEvent:
             return [RNPEvent request:@"event" completionHandler:resolve];
         case RNPTypeReminder:
             return [RNPEvent request:@"reminder" completionHandler:resolve];
+#endif
+#ifdef RNP_USE_BLUETOOTH
         case RNPTypeBluetooth:
             return [self requestBluetooth:resolve];
+#endif
         case RNPTypeNotification:
             return [self requestNotification:json resolve:resolve];
+#ifdef RNP_USE_SPEECH
         case RNPTypeSpeechRecognition:
             return [RNPSpeechRecognition request:resolve];
+#endif
+#ifdef RNP_USE_MEDIALIBRARY
         case RNPTypeMediaLibrary:
             return [RNPMediaLibrary request:resolve];
+#endif
+#ifdef RNP_USE_MOTION
         case RNPTypeMotion:
             return [RNPMotion request:resolve];
+#endif
         default:
             break;
     }
-
-
 }
 
+#ifdef RNP_USE_LOCATION
 - (void) requestLocation:(id)json resolve:(RCTPromiseResolveBlock)resolve
 {
     if (self.locationMgr == nil) {
@@ -207,6 +274,7 @@ RCT_REMAP_METHOD(requestPermission, permissionType:(RNPType)type json:(id)json r
 
     [self.locationMgr request:type completionHandler:resolve];
 }
+#endif
 
 - (void) requestNotification:(id)json resolve:(RCTPromiseResolveBlock)resolve
 {
@@ -231,7 +299,7 @@ RCT_REMAP_METHOD(requestPermission, permissionType:(RNPType)type json:(id)json r
 
 }
 
-
+#ifdef RNP_USE_BLUETOOTH
 - (void) requestBluetooth:(RCTPromiseResolveBlock)resolve
 {
     if (self.bluetoothMgr == nil) {
@@ -240,6 +308,7 @@ RCT_REMAP_METHOD(requestPermission, permissionType:(RNPType)type json:(id)json r
 
     [self.bluetoothMgr request:resolve];
 }
+#endif
 
 
 

--- a/ios/ReactNativePermissions.xcodeproj/project.pbxproj
+++ b/ios/ReactNativePermissions.xcodeproj/project.pbxproj
@@ -61,6 +61,7 @@
 		6695820A1FE441A8008596CD /* RNPEvent.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNPEvent.m; sourceTree = "<group>"; };
 		6695820B1FE441A8008596CD /* RNPSpeechRecognition.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNPSpeechRecognition.h; sourceTree = "<group>"; };
 		6695820C1FE441A8008596CD /* RNPNotification.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNPNotification.h; sourceTree = "<group>"; };
+		8ED4765F22324F6D00E485C7 /* RNPFeature.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RNPFeature.h; sourceTree = "<group>"; };
 		9D23B34F1C767B80008B4819 /* libReactNativePermissions.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libReactNativePermissions.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		D0AD62302000656F00D89898 /* RNPMotion.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNPMotion.h; sourceTree = "<group>"; };
 		D0AD62312000657000D89898 /* RNPMotion.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNPMotion.m; sourceTree = "<group>"; };
@@ -111,6 +112,7 @@
 				669582031FE441A7008596CD /* RNPPhoto.m */,
 				6695820B1FE441A8008596CD /* RNPSpeechRecognition.h */,
 				669581FD1FE441A7008596CD /* RNPSpeechRecognition.m */,
+				8ED4765F22324F6D00E485C7 /* RNPFeature.h */,
 			);
 			path = Permissions;
 			sourceTree = "<group>";


### PR DESCRIPTION
# Usage

Add some of these preprocessor macros to control whether relative codes should be compiled or not.

permission         | include             | exclude
-------------------|---------------------|-------------------
location           | `RNP_LOCATIO`       | `RNP_LOCATION_REMOVE`
calendar           | `RNP_CALENDAR`      | `RNP_CALDENDAR_REMOVE`
bluetooth          | `RNP_BLUETOOTH`     | `RNP_BLUETOOTH_REMOVE`
audio/video        | `RNP_AUDIOVIDEO`    | `RNP_AUDIOVIDEO_REMOVE`
photo              | `RNP_PHOTO`         | `RNP_PHOTO_REMOVE`
contact            | `RNP_CONTACT`       | `RNP_CONTACT_REMOVE`
motion             | `RNP_MOTION`        | `RNP_MOTION_REMOVE`
media/ apple music | `RNP_MEDIALIBRARY`  | `RNP_MEDIALIBRARY_REMOVE`
speech             | `RNP_SPEECH`        | `RNP_SPEECH_REMOVE`

Generally speaking, **DO NOT** define both `RNP_X` and `RNP_X_REMOVE`. The priority of macros table is showed below:
 
RNP_ALL   | RNP_X           | RNP_X_REMOVE  | compliation
-----------|-------------|------------------|-------------
define        |  not define   |   not defien          |   YES
not define  |    define       |    not define         |   YES
not care     |   not care     |    define               |    NO

# For cocoapod

Using pod file hook to set macros

```podfile
post_install do |installer_representation|
  installer_representation.pods_project.targets.each do |target|
    if target.name == 'ReactNativePermissions'
      target.build_configurations.each do |config|
        config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] ||= ['$(inherited)']
        config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] << 'RNP_PHOTO'
      end
    end
  end
end
```